### PR TITLE
DM-21743: Deploy watcher on Tucson test stand and in the summit

### DIFF
--- a/Watcher/v1/_labels.yaml
+++ b/Watcher/v1/_labels.yaml
@@ -1,2 +1,3 @@
 # Labels for recommended settings; a dict of label: config_file
 summit: summit.yaml
+tucson: tucson.yaml

--- a/Watcher/v1/tucson.yaml
+++ b/Watcher/v1/tucson.yaml
@@ -1,20 +1,21 @@
 rules:
 - classname: Enabled
   configs:
-  - name: ATDome
+  - name: ATCamera
+  - name: ATSpectrograph
+  - name: ScriptQueue
+  - name: ATArchiver
+  - name: ATHeaderService
   - name: ATDomeTrajectory
   - name: ATHexapod
   - name: ATMCS
   - name: ATPneumatics
   - name: ATPtg
-  - name: Environment
-  - name: ATAOS
-  - name: GenericCamera
 - classname: Heartbeat
   configs:
-  - name: ATDome
   - name: ATDomeTrajectory
   - name: ATHexapod
   - name: Environment
-  - name: ATAOS
-  - name: GenericCamera
+  - name: ScriptQueue
+  - name: ATHeaderService
+  - name: ATSpectrograph


### PR DESCRIPTION
Add ATAOS and GenericCamera to the list of components for the watcher to monitor on the summit.
Add configuration for the Tucson test stand.