### PR TITLE
DM-25856: Revert "Add Hexapod and Rotator"

### DIFF
--- a/Hexapod/README.rst
+++ b/Hexapod/README.rst
@@ -1,1 +1,0 @@
-Configuration files for the Hexapod CSC

--- a/Hexapod/v1/_labels.yaml
+++ b/Hexapod/v1/_labels.yaml
@@ -1,1 +1,0 @@
-# Labels for recommended settings; a dict of label: config_file

--- a/Rotator/README.rst
+++ b/Rotator/README.rst
@@ -1,6 +1,0 @@
-Configuration files for the Rotator CSC.
-
-The Rotator does not have any configuration.
-However, both the Hexapod and Rotator CSCs
-inherit from the same base class,
-which is configurable because Hexapod is configurable.

--- a/Rotator/v1/_labels.yaml
+++ b/Rotator/v1/_labels.yaml
@@ -1,1 +1,0 @@
-# Labels for recommended settings; a dict of label: config_file

--- a/tests/test_config_files.py
+++ b/tests/test_config_files.py
@@ -56,16 +56,6 @@ class ConfigTestCase(salobj.BaseConfigTestCase, unittest.TestCase):
                                          package_name="ts_GenericCamera",
                                          config_package_root=self.config_package_root)
 
-    def test_Hexapod(self):
-        self.check_standard_config_files(sal_name="Hexapod",
-                                         module_name="lsst.ts.hexapod",
-                                         config_package_root=self.config_package_root)
-
-    def test_Rotator(self):
-        self.check_standard_config_files(sal_name="Rotator",
-                                         module_name="lsst.ts.rotator",
-                                         config_package_root=self.config_package_root)
-
     def test_Test(self):
         self.check_standard_config_files(sal_name="Test",
                                          module_name="lsst.ts.salobj",


### PR DESCRIPTION
This reverts commit 0d08f27e0e3dd66d621116e46c26ba82b7b67367
because the Hexapod and Rotator files belong in ts_config_mttcs.