### PR TITLE
In the Scheduler configuration:

### DIFF
--- a/Scheduler/feature_scheduler/standstill.py
+++ b/Scheduler/feature_scheduler/standstill.py
@@ -1,5 +1,0 @@
-from rubin_sim.scheduler.schedulers import Core_scheduler
-
-if __name__ == "config":
-    nside=32
-    scheduler = Core_scheduler([], nside=nside)

--- a/Scheduler/v3/_labels.yaml
+++ b/Scheduler/v3/_labels.yaml
@@ -1,6 +1,4 @@
+standstill: standstill.yaml
 auxtel_summit: fbs_summit_20211104_spec_image_survey.yaml
-auxtel_summit_fbs_spec_image_survey: fbs_20211007_spec_image_survey.yaml
-maintel_summit: maintel_summit_standstill.yaml
-auxtel_nts: auxtel_nts_standstill.yaml
-auxtel_nts_fbs_spec_image_survey: fbs_nts_20211007_spec_image_survey.yaml
-maintel_nts: maintel_nts_standstill.yaml
+auxtel_tts: fbs_tts_20211007_spec_image_survey.yaml
+auxtel_nts: fbs_nts_20211007_spec_image_survey.yaml

--- a/Scheduler/v3/auxtel_nts_standstill.yaml
+++ b/Scheduler/v3/auxtel_nts_standstill.yaml
@@ -1,8 +1,0 @@
-driver_type: lsst.ts.scheduler.driver.feature_scheduler
-mode: ADVANCE
-s3instance: nts
-driver_configuration:
-  default_observing_script_name: auxtel/track_target_and_take_image.py
-  default_observing_script_is_standard: true
-  stop_tracking_observing_script_name: auxtel/stop_tracking.py
-  scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/standstill.py

--- a/Scheduler/v3/auxtel_summit_standstill.yaml
+++ b/Scheduler/v3/auxtel_summit_standstill.yaml
@@ -1,7 +1,0 @@
-driver_type: lsst.ts.scheduler.driver.feature_scheduler
-mode: ADVANCE
-driver_configuration:
-  default_observing_script_name: auxtel/track_target_and_take_image.py
-  default_observing_script_is_standard: true
-  stop_tracking_observing_script_name: auxtel/stop_tracking.py
-  scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/standstill.py

--- a/Scheduler/v3/fbs_tts_20211007_spec_image_survey.yaml
+++ b/Scheduler/v3/fbs_tts_20211007_spec_image_survey.yaml
@@ -1,0 +1,83 @@
+driver_type: lsst.ts.scheduler.driver.feature_scheduler
+mode: ADVANCE
+s3instance: tuc
+models:
+  observatory_model:
+    camera:
+      filter_max_changes_burst_num: 1
+      filter_max_changes_avg_num: 30000
+    optics_loop_corr:
+      tel_optics_cl_alt_limit:
+        - 0
+        - 30
+        - 90
+driver_configuration:
+  default_observing_script_name: auxtel/track_target_and_take_image.py
+  default_observing_script_is_standard: true
+  stop_tracking_observing_script_name: auxtel/stop_tracking.py
+  scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/2021/10/07/fbs_config_spec_image_survey.py
+  survey_observing_script:
+    cwfs:
+      observing_script_name: auxtel/latiss_cwfs_align.py
+      observing_script_is_standard: false
+    spec:
+      observing_script_name: auxtel/latiss_acquire_and_take_sequence.py
+      observing_script_is_standard: false
+  script_configuration:
+    script_configuration:
+      grating: empty_1
+      band_filter: SDSSg
+    script_configuration_cwfs:
+      filter: FELH0600
+      find_target:
+        mag_limit: 8.0
+    script_configuration_spec:
+      do_acquire: True
+      acq_filter: BG40
+      acq_grating: ronchi170lpmm
+      do_take_sequence: True
+      exposure_time_sequence:
+        - 20
+        - 20
+        - 20
+        - 20
+        - 20
+        - 20
+        - 20
+        - 20
+      filter_sequence:
+        - empty_1
+        - SDSSg
+        - BG40
+        - FELH0600
+        - empty_1
+        - SDSSg
+        - BG40
+        - FELH0600
+      grating_sequence:
+        - ronchi170lpmm
+        - ronchi170lpmm
+        - ronchi170lpmm
+        - ronchi170lpmm
+        - holo4_003
+        - holo4_003
+        - holo4_003
+        - holo4_003
+telemetry:
+  efd_name: tucson_teststand_efd
+  streams:
+    - name: seeing
+      efd_table: lsst.sal.DIMM.logevent_dimmMeasurement
+      efd_columns:
+        - fwhm
+      efd_delta_time: 300.0
+    - name: wind_speed
+      efd_table: lsst.sal.WeatherStation.windSpeed
+      efd_columns:
+        - avg2M
+      efd_delta_time: 300.0
+    - name: wind_direction
+      efd_table: lsst.sal.WeatherStation.windDirection
+      efd_columns:
+        - avg2M
+      efd_delta_time: 300.0

--- a/Scheduler/v3/maintel_nts_standstill.yaml
+++ b/Scheduler/v3/maintel_nts_standstill.yaml
@@ -1,7 +1,0 @@
-driver_type: lsst.ts.scheduler.driver.feature_scheduler
-mode: ADVANCE
-s3instance: nts
-driver_configuration:
-  default_observing_script_name: maintel/track_target_and_take_image.py
-  default_observing_script_is_standard: true
-  scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/standstill.py

--- a/Scheduler/v3/maintel_summit_standstill.yaml
+++ b/Scheduler/v3/maintel_summit_standstill.yaml
@@ -1,6 +1,0 @@
-driver_type: lsst.ts.scheduler.driver.feature_scheduler
-mode: ADVANCE
-driver_configuration:
-  default_observing_script_name: maintel/track_target_and_take_image.py
-  default_observing_script_is_standard: true
-  scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/standstill.py

--- a/Scheduler/v3/standstill.yaml
+++ b/Scheduler/v3/standstill.yaml
@@ -1,0 +1,4 @@
+mode: DRY
+driver_configuration:
+  general_propos:
+    - StandStill


### PR DESCRIPTION
  * Remove bad "standstill" configurations.
  * Add a new standstill configuration that will configure the scheduler in DRY mode.
    This mode does not configure a Driver and won't produce any target.
    This is mostly for testing purposes and can be used with any instance of the Scheduler.
  * Add configuration for auxtel on tts with an imaging and spectroscopic survey.