### PR TITLE
Add scheduler configuration for 2022-10A run

### DIFF
--- a/Scheduler/feature_scheduler/auxtel/2022/10/fbs_config_image_survey.py
+++ b/Scheduler/feature_scheduler/auxtel/2022/10/fbs_config_image_survey.py
@@ -1,0 +1,88 @@
+# This file is part of ts_config_ocs.
+#
+# Developed for the Vera Rubin Observatory Telescope and Site System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from lsst.ts.fbs.utils import Tiles
+
+from lsst.ts.fbs.utils.auxtel.make_scheduler import MakeScheduler, SurveyType
+
+
+def get_scheduler():
+    """Construct feature based scheduler.
+
+    Returns
+    -------
+    nside : int
+        Healpix map resolution.
+    scheduler : Core_scheduler
+        Feature based scheduler.
+    """
+    nside = 64
+    reward_values = dict(
+        default=10.0,
+    )
+
+    image_nexp = 2  # number of exposures
+    image_exptime = 60.0  # total exposure time in seconds
+    image_visit_gap = 1440.0
+    wind_speed_maximum = 13.0  # maximum direct wind in m/s
+
+    image_ha_limit = [
+        (24.0 - 3.5, 24.0),
+        (0.0, 3.5),
+    ]
+    image_ha_limit_pole = [
+        (0.0, 24.0),
+    ]
+
+    image_tiles = [
+        Tiles(
+            survey_name="LATISS_POLE",
+            hour_angle_limit=image_ha_limit_pole,
+            reward_value=reward_values["default"],
+            filters=["g", "r", "i"],
+            visit_gap=image_visit_gap,
+            exptime=image_exptime,
+            nexp=image_nexp,
+        ),
+        Tiles(
+            survey_name="AUXTEL_DRP_IMAGING",
+            hour_angle_limit=image_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["g", "r", "i"],
+            visit_gap=image_visit_gap,
+            exptime=image_exptime,
+            nexp=image_nexp,
+        ),
+    ]
+
+    make_scheduler = MakeScheduler()
+
+    return make_scheduler.get_scheduler(
+        nside=nside,
+        wind_speed_maximum=wind_speed_maximum,
+        survey_type=SurveyType.Image,
+        spec_targets=[],
+        image_tiles=image_tiles,
+    )
+
+
+if __name__ == "config":
+    nside, scheduler = get_scheduler()

--- a/Scheduler/feature_scheduler/auxtel/2022/10/fbs_config_spec_survey.py
+++ b/Scheduler/feature_scheduler/auxtel/2022/10/fbs_config_spec_survey.py
@@ -1,0 +1,261 @@
+# This file is part of ts_config_ocs.
+#
+# Developed for the Vera Rubin Observatory Telescope and Site System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from astropy import units
+
+from astropy.coordinates import Angle
+
+from lsst.ts.fbs.utils import Target, Tiles
+
+from lsst.ts.fbs.utils.auxtel.make_scheduler import MakeScheduler, SurveyType
+
+
+def get_scheduler():
+    """Construct feature based scheduler.
+
+    Returns
+    -------
+    nside : int
+        Healpix map resolution.
+    scheduler : Core_scheduler
+        Feature based scheduler.
+    """
+    nside = 64
+    reward_values = dict(
+        default=10.0,
+        image_pole=1.0,
+        image_survey=2.0,
+        spec_pole=20.0,
+    )
+
+    image_nexp = 2  # number of exposures
+    image_exptime = 60.0  # total exposure time in seconds
+    image_visit_gap = 1440.0
+    wind_speed_maximum = 13.0  # maximum direct wind in m/s
+
+    spec_ha_limit = [
+        (18.0, 24.0),
+        (0.0, 6.0),
+    ]
+    spec_ha_limit_pole = [
+        (0.0, 24.0),
+    ]
+    image_ha_limit = [
+        (24.0 - 3.5, 24.0),
+        (0.0, 3.5),
+    ]
+    image_ha_limit_pole = [
+        (0.0, 24.0),
+    ]
+
+    spec_target_list = [
+        Target(
+            target_name="HD185975",
+            survey_name="spec",
+            ra=Angle("20:28:18", unit=units.hourangle),
+            dec=Angle("-87:28:19.9", unit=units.deg),
+            hour_angle_limit=spec_ha_limit_pole,
+            reward_value=reward_values["spec_pole"],
+            filters=["r"],
+            visit_gap=60.0,
+            exptime=120.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD2811",
+            survey_name="spec",
+            ra=Angle("00:31:18", unit=units.hourangle),
+            dec=Angle("-43:36:23.0", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=6.0,
+            exptime=120.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD009051",
+            survey_name="spec",
+            ra=Angle("01:28:46", unit=units.hourangle),
+            dec=Angle("-24:20:25.4", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=6.0,
+            exptime=120.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD14943",
+            survey_name="spec",
+            ra=Angle("02:22:54", unit=units.hourangle),
+            dec=Angle("-51:05:31.7", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=6.0,
+            exptime=120.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD031128",
+            survey_name="spec",
+            ra=Angle("04:52:09", unit=units.hourangle),
+            dec=Angle("-27:03:50.9", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=6.0,
+            exptime=120.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD37962",
+            survey_name="spec",
+            ra=Angle("05:40:51", unit=units.hourangle),
+            dec=Angle("-31:21:04.0", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=6.0,
+            exptime=120.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="MU-COL",
+            survey_name="spec",
+            ra=Angle("05:46:00", unit=units.hourangle),
+            dec=Angle("-32:18:23.2", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=6.0,
+            exptime=120.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD38949",
+            survey_name="spec",
+            ra=Angle("05:48:20", unit=units.hourangle),
+            dec=Angle("-24:27:49.9", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=6.0,
+            exptime=120.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="ETA1-DOR",
+            survey_name="spec",
+            ra=Angle("06:06:09", unit=units.hourangle),
+            dec=Angle("-66:02:23", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=6.0,
+            exptime=120.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD60753",
+            survey_name="spec",
+            ra=Angle("07:33:27", unit=units.hourangle),
+            dec=Angle("-50:35:03.3", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=6.0,
+            exptime=120.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD167060",
+            survey_name="spec",
+            ra=Angle("18:17:44", unit=units.hourangle),
+            dec=Angle("-61:42:31.6", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=6.0,
+            exptime=120.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD200654",
+            survey_name="spec",
+            ra=Angle("21:06:34", unit=units.hourangle),
+            dec=Angle("-49:57:50.3", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=6.0,
+            exptime=120.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD205905",
+            survey_name="spec",
+            ra=Angle("21:39:10", unit=units.hourangle),
+            dec=Angle("-27:18:23.7", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=6.0,
+            exptime=120.0,
+            nexp=1,
+        ),
+    ]
+
+    image_tiles = [
+        Tiles(
+            survey_name="LATISS_POLE",
+            hour_angle_limit=image_ha_limit_pole,
+            reward_value=reward_values["image_pole"],
+            filters=["g", "r", "i"],
+            visit_gap=image_visit_gap,
+            exptime=image_exptime,
+            nexp=image_nexp,
+        ),
+        Tiles(
+            survey_name="AUXTEL_DRP_IMAGING",
+            hour_angle_limit=image_ha_limit,
+            reward_value=reward_values["image_survey"],
+            filters=["g", "r", "i"],
+            visit_gap=image_visit_gap,
+            exptime=image_exptime,
+            nexp=image_nexp,
+        ),
+    ]
+
+    make_scheduler = MakeScheduler()
+
+    return make_scheduler.get_scheduler(
+        nside=nside,
+        wind_speed_maximum=wind_speed_maximum,
+        survey_type=SurveyType.SpecImage,
+        spec_targets=spec_target_list,
+        image_tiles=image_tiles,
+    )
+
+
+if __name__ == "config":
+    nside, scheduler = get_scheduler()

--- a/Scheduler/v4/auxtel_fbs_image_202210A.yaml
+++ b/Scheduler/v4/auxtel_fbs_image_202210A.yaml
@@ -1,6 +1,7 @@
 driver_type: lsst.ts.scheduler.driver.feature_scheduler
 mode: ADVANCE
-startup_type: HOT
+startup_type: COLD
+startup_database: /home/saluser/rubin_sim_data/fbs_observation_database.sql
 models:
   observatory_model:
     camera:
@@ -15,7 +16,7 @@ driver_configuration:
   parameters:
     night_boundary: -10.0
   observation_database_name: /home/saluser/rubin_sim_data/fbs_observation_database.sql
-  scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/2022/09/fbs_config_image_survey.py
+  scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/2022/10/fbs_config_image_survey.py
   default_observing_script_name: auxtel/track_target_and_take_image.py
   default_observing_script_is_standard: true
   stop_tracking_observing_script_name: auxtel/stop_tracking.py
@@ -30,7 +31,8 @@ driver_configuration:
     script_configuration:
       grating: empty_1
       filter_prefix: SDSS
+      filter_suffix: _65mm
     script_configuration_cwfs:
-      filter: SDSSr
+      filter: SDSSr_65mm
       find_target:
         mag_limit: 8.0

--- a/Scheduler/v4/auxtel_fbs_image_202210A_hot.yaml
+++ b/Scheduler/v4/auxtel_fbs_image_202210A_hot.yaml
@@ -15,7 +15,7 @@ driver_configuration:
   parameters:
     night_boundary: -10.0
   observation_database_name: /home/saluser/rubin_sim_data/fbs_observation_database.sql
-  scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/2022/09/fbs_config_spec_survey.py
+  scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/2022/10/fbs_config_image_survey.py
   default_observing_script_name: auxtel/track_target_and_take_image.py
   default_observing_script_is_standard: true
   stop_tracking_observing_script_name: auxtel/stop_tracking.py
@@ -30,42 +30,8 @@ driver_configuration:
     script_configuration:
       grating: empty_1
       filter_prefix: SDSS
+      filter_suffix: _65mm
     script_configuration_cwfs:
-      filter: SDSSr
+      filter: SDSSr_65mm
       find_target:
         mag_limit: 8.0
-    script_configuration_spec:
-      do_acquire: True
-      acq_filter: empty_1
-      acq_grating: ronchi170lpmm
-      acq_exposure_time: 5.0
-      program: spec
-      do_blind_offset: False
-      do_take_sequence: True
-      exposure_time_sequence:
-        - 30.0
-        - 30.0
-        - 30.0
-        - 30.0
-        - 30.0
-        - 30.0
-        - 30.0
-        - 30.0
-      filter_sequence:
-        - empty_1
-        - empty_1
-        - FELH0600
-        - FELH0600
-        - FELH0600
-        - FELH0600
-        - empty_1
-        - empty_1
-      grating_sequence:
-        - ronchi170lpmm
-        - ronchi170lpmm
-        - ronchi170lpmm
-        - ronchi170lpmm
-        - holo4_003
-        - holo4_003
-        - holo4_003
-        - holo4_003

--- a/Scheduler/v4/auxtel_fbs_spec_202210A.yaml
+++ b/Scheduler/v4/auxtel_fbs_spec_202210A.yaml
@@ -16,7 +16,7 @@ driver_configuration:
   parameters:
     night_boundary: -10.0
   observation_database_name: /home/saluser/rubin_sim_data/fbs_observation_database.sql
-  scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/2022/09/fbs_config_spec_survey.py
+  scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/2022/10/fbs_config_spec_survey.py
   default_observing_script_name: auxtel/track_target_and_take_image.py
   default_observing_script_is_standard: true
   stop_tracking_observing_script_name: auxtel/stop_tracking.py
@@ -31,8 +31,9 @@ driver_configuration:
     script_configuration:
       grating: empty_1
       filter_prefix: SDSS
+      filter_suffix: _65mm
     script_configuration_cwfs:
-      filter: SDSSr
+      filter: SDSSr_65mm
       find_target:
         mag_limit: 8.0
     script_configuration_spec:
@@ -48,25 +49,13 @@ driver_configuration:
         - 30.0
         - 30.0
         - 30.0
-        - 30.0
-        - 30.0
-        - 30.0
-        - 30.0
       filter_sequence:
         - empty_1
         - empty_1
-        - FELH0600
-        - FELH0600
-        - FELH0600
-        - FELH0600
         - empty_1
         - empty_1
       grating_sequence:
         - ronchi170lpmm
         - ronchi170lpmm
-        - ronchi170lpmm
-        - ronchi170lpmm
-        - holo4_003
-        - holo4_003
         - holo4_003
         - holo4_003

--- a/Scheduler/v4/auxtel_fbs_spec_202210A_hot.yaml
+++ b/Scheduler/v4/auxtel_fbs_spec_202210A_hot.yaml
@@ -1,7 +1,6 @@
 driver_type: lsst.ts.scheduler.driver.feature_scheduler
 mode: ADVANCE
-startup_type: COLD
-startup_database: /home/saluser/rubin_sim_data/fbs_observation_database.sql
+startup_type: HOT
 models:
   observatory_model:
     camera:
@@ -16,7 +15,7 @@ driver_configuration:
   parameters:
     night_boundary: -10.0
   observation_database_name: /home/saluser/rubin_sim_data/fbs_observation_database.sql
-  scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/2022/09/fbs_config_image_survey.py
+  scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/2022/10/fbs_config_spec_survey.py
   default_observing_script_name: auxtel/track_target_and_take_image.py
   default_observing_script_is_standard: true
   stop_tracking_observing_script_name: auxtel/stop_tracking.py
@@ -31,7 +30,31 @@ driver_configuration:
     script_configuration:
       grating: empty_1
       filter_prefix: SDSS
+      filter_suffix: _65mm
     script_configuration_cwfs:
-      filter: SDSSr
+      filter: SDSSr_65mm
       find_target:
         mag_limit: 8.0
+    script_configuration_spec:
+      do_acquire: True
+      acq_filter: empty_1
+      acq_grating: ronchi170lpmm
+      acq_exposure_time: 5.0
+      program: spec
+      do_blind_offset: False
+      do_take_sequence: True
+      exposure_time_sequence:
+        - 30.0
+        - 30.0
+        - 30.0
+        - 30.0
+      filter_sequence:
+        - empty_1
+        - empty_1
+        - empty_1
+        - empty_1
+      grating_sequence:
+        - ronchi170lpmm
+        - ronchi170lpmm
+        - holo4_003
+        - holo4_003


### PR DESCRIPTION
Added new filters for imaging survey (SDSSg_65mm, SDSSr_65mm, SDSSi_65mm), removed LAM-LEP and filters from spectroscopic target list. 