### PR TITLE
Add scheduler configuration files for 2023-01A AuxTel run

### DIFF
--- a/Scheduler/feature_scheduler/auxtel/fbs_config_image_survey.py
+++ b/Scheduler/feature_scheduler/auxtel/fbs_config_image_survey.py
@@ -1,0 +1,89 @@
+# This file is part of ts_config_ocs.
+#
+# Developed for the Vera Rubin Observatory Telescope and Site System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from lsst.ts.fbs.utils import Tiles
+
+from lsst.ts.fbs.utils.auxtel.make_scheduler import MakeScheduler, SurveyType
+
+
+def get_scheduler():
+    """Construct feature based scheduler.
+
+    Returns
+    -------
+    nside : int
+        Healpix map resolution.
+    scheduler : Core_scheduler
+        Feature based scheduler.
+    """
+    nside = 64
+    reward_values = dict(
+        default=10.0,
+        image_pole=5.0,
+    )
+
+    image_nexp = 2  # number of exposures
+    image_exptime = 60.0  # total exposure time in seconds
+    image_visit_gap = 60.0
+    wind_speed_maximum = 13.0  # maximum direct wind in m/s
+
+    image_ha_limit = [
+        (24.0 - 3.5, 24.0),
+        (0.0, 3.5),
+    ]
+    image_ha_limit_pole = [
+        (0.0, 24.0),
+    ]
+
+    image_tiles = [
+        Tiles(
+            survey_name="LATISS_POLE",
+            hour_angle_limit=image_ha_limit_pole,
+            reward_value=reward_values["image_pole"],
+            filters=["r"],
+            visit_gap=image_visit_gap,
+            exptime=image_exptime,
+            nexp=image_nexp,
+        ),
+        Tiles(
+            survey_name="AUXTEL_DRP_IMAGING",
+            hour_angle_limit=image_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=image_visit_gap,
+            exptime=image_exptime,
+            nexp=image_nexp,
+        ),
+    ]
+
+    make_scheduler = MakeScheduler()
+
+    return make_scheduler.get_scheduler(
+        nside=nside,
+        wind_speed_maximum=wind_speed_maximum,
+        survey_type=SurveyType.Image,
+        spec_targets=[],
+        image_tiles=image_tiles,
+    )
+
+
+if __name__ == "config":
+    nside, scheduler = get_scheduler()

--- a/Scheduler/feature_scheduler/auxtel/fbs_config_spec_survey.py
+++ b/Scheduler/feature_scheduler/auxtel/fbs_config_spec_survey.py
@@ -1,0 +1,285 @@
+# This file is part of ts_config_ocs.
+#
+# Developed for the Vera Rubin Observatory Telescope and Site System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from astropy import units
+
+from astropy.coordinates import Angle
+
+from lsst.ts.fbs.utils import Target, Tiles
+
+from lsst.ts.fbs.utils.auxtel.make_scheduler import MakeScheduler, SurveyType
+
+
+def get_scheduler():
+    """Construct feature based scheduler.
+
+    Returns
+    -------
+    nside : int
+        Healpix map resolution.
+    scheduler : Core_scheduler
+        Feature based scheduler.
+    """
+    nside = 64
+    reward_values = dict(
+        default=10.0,
+        image_pole=1.0,
+        image_survey=2.0,
+        spec_pole=20.0,
+    )
+
+    image_nexp = 2  # number of exposures
+    image_exptime = 60.0  # total exposure time in seconds
+    image_visit_gap = 60.0
+    wind_speed_maximum = 13.0  # maximum direct wind in m/s
+
+    spec_ha_limit = [
+        (18.0, 24.0),
+        (0.0, 6.0),
+    ]
+    spec_ha_limit_pole = [
+        (0.0, 24.0),
+    ]
+    image_ha_limit = [
+        (24.0 - 3.5, 24.0),
+        (0.0, 3.5),
+    ]
+    image_ha_limit_pole = [
+        (0.0, 24.0),
+    ]
+
+    spec_target_list = [
+        Target(
+            target_name="HD185975",
+            survey_name="spec",
+            ra=Angle("20:28:18", unit=units.hourangle),
+            dec=Angle("-87:28:19.9", unit=units.deg),
+            hour_angle_limit=spec_ha_limit_pole,
+            reward_value=reward_values["spec_pole"],
+            filters=["r"],
+            visit_gap=30.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD2811",
+            survey_name="spec",
+            ra=Angle("00:31:18", unit=units.hourangle),
+            dec=Angle("-43:36:23.0", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD009051",
+            survey_name="spec",
+            ra=Angle("01:28:46", unit=units.hourangle),
+            dec=Angle("-24:20:25.4", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD14943",
+            survey_name="spec",
+            ra=Angle("02:22:54", unit=units.hourangle),
+            dec=Angle("-51:05:31.7", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD031128",
+            survey_name="spec",
+            ra=Angle("04:52:09", unit=units.hourangle),
+            dec=Angle("-27:03:50.9", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD37962",
+            survey_name="spec",
+            ra=Angle("05:40:51", unit=units.hourangle),
+            dec=Angle("-31:21:04.0", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="MU-COL",
+            survey_name="spec",
+            ra=Angle("05:46:00", unit=units.hourangle),
+            dec=Angle("-32:18:23.2", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD38949",
+            survey_name="spec",
+            ra=Angle("05:48:20", unit=units.hourangle),
+            dec=Angle("-24:27:49.9", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="ETA1-DOR",
+            survey_name="spec",
+            ra=Angle("06:06:09", unit=units.hourangle),
+            dec=Angle("-66:02:23", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD60753",
+            survey_name="spec",
+            ra=Angle("07:33:27", unit=units.hourangle),
+            dec=Angle("-50:35:03.3", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD074000",
+            survey_name="spec",
+            ra=Angle("08:40:50", unit=units.hourangle),
+            dec=Angle("-16:20:42.5", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=60.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD111980",
+            survey_name="spec",
+            ra=Angle("12:53:15", unit=units.hourangle),
+            dec=Angle("-18:31:20.0", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD1151169",
+            survey_name="spec",
+            ra=Angle("13:15:47", unit=units.hourangle),
+            dec=Angle("-29:30:21.2", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD200654",
+            survey_name="spec",
+            ra=Angle("21:06:34", unit=units.hourangle),
+            dec=Angle("-49:57:50.3", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD205905",
+            survey_name="spec",
+            ra=Angle("21:39:10", unit=units.hourangle),
+            dec=Angle("-27:18:23.7", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+    ]
+
+    image_tiles = [
+        Tiles(
+            survey_name="LATISS_POLE",
+            hour_angle_limit=image_ha_limit_pole,
+            reward_value=reward_values["image_pole"],
+            filters=["r"],
+            visit_gap=image_visit_gap,
+            exptime=image_exptime,
+            nexp=image_nexp,
+        ),
+        Tiles(
+            survey_name="AUXTEL_DRP_IMAGING",
+            hour_angle_limit=image_ha_limit,
+            reward_value=reward_values["image_survey"],
+            filters=["r"],
+            visit_gap=image_visit_gap,
+            exptime=image_exptime,
+            nexp=image_nexp,
+        ),
+    ]
+
+    make_scheduler = MakeScheduler()
+
+    return make_scheduler.get_scheduler(
+        nside=nside,
+        wind_speed_maximum=wind_speed_maximum,
+        survey_type=SurveyType.SpecImage,
+        spec_targets=spec_target_list,
+        image_tiles=image_tiles,
+    )
+
+
+if __name__ == "config":
+    nside, scheduler = get_scheduler()

--- a/Scheduler/feature_scheduler/auxtel/fbs_config_spec_survey_photometric.py
+++ b/Scheduler/feature_scheduler/auxtel/fbs_config_spec_survey_photometric.py
@@ -1,0 +1,286 @@
+# This file is part of ts_config_ocs.
+#
+# Developed for the Vera Rubin Observatory Telescope and Site System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from astropy import units
+
+from astropy.coordinates import Angle
+
+from lsst.ts.fbs.utils import Target, Tiles
+
+from lsst.ts.fbs.utils.auxtel.make_scheduler import MakeScheduler, SurveyType
+
+
+def get_scheduler():
+    """Construct feature based scheduler.
+
+    Returns
+    -------
+    nside : int
+        Healpix map resolution.
+    scheduler : Core_scheduler
+        Feature based scheduler.
+    """
+    nside = 64
+    reward_values = dict(
+        default=10.0,
+        image_pole=1.0,
+        image_survey=2.0,
+        spec_pole=30.0,
+        spec_mucol=20.0,
+    )
+
+    image_nexp = 2  # number of exposures
+    image_exptime = 60.0  # total exposure time in seconds
+    image_visit_gap = 60.0
+    wind_speed_maximum = 13.0  # maximum direct wind in m/s
+
+    spec_ha_limit = [
+        (18.0, 24.0),
+        (0.0, 6.0),
+    ]
+    spec_ha_limit_pole = [
+        (0.0, 24.0),
+    ]
+    image_ha_limit = [
+        (24.0 - 3.5, 24.0),
+        (0.0, 3.5),
+    ]
+    image_ha_limit_pole = [
+        (0.0, 24.0),
+    ]
+
+    spec_target_list = [
+        Target(
+            target_name="HD185975",
+            survey_name="spec",
+            ra=Angle("20:28:18", unit=units.hourangle),
+            dec=Angle("-87:28:19.9", unit=units.deg),
+            hour_angle_limit=spec_ha_limit_pole,
+            reward_value=reward_values["spec_pole"],
+            filters=["r"],
+            visit_gap=30.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD2811",
+            survey_name="spec",
+            ra=Angle("00:31:18", unit=units.hourangle),
+            dec=Angle("-43:36:23.0", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD009051",
+            survey_name="spec",
+            ra=Angle("01:28:46", unit=units.hourangle),
+            dec=Angle("-24:20:25.4", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD14943",
+            survey_name="spec",
+            ra=Angle("02:22:54", unit=units.hourangle),
+            dec=Angle("-51:05:31.7", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD031128",
+            survey_name="spec",
+            ra=Angle("04:52:09", unit=units.hourangle),
+            dec=Angle("-27:03:50.9", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD37962",
+            survey_name="spec",
+            ra=Angle("05:40:51", unit=units.hourangle),
+            dec=Angle("-31:21:04.0", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="MU-COL",
+            survey_name="spec",
+            ra=Angle("05:46:00", unit=units.hourangle),
+            dec=Angle("-32:18:23.2", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["spec_mucol"],
+            filters=["r"],
+            visit_gap=1.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD38949",
+            survey_name="spec",
+            ra=Angle("05:48:20", unit=units.hourangle),
+            dec=Angle("-24:27:49.9", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="ETA1-DOR",
+            survey_name="spec",
+            ra=Angle("06:06:09", unit=units.hourangle),
+            dec=Angle("-66:02:23", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD60753",
+            survey_name="spec",
+            ra=Angle("07:33:27", unit=units.hourangle),
+            dec=Angle("-50:35:03.3", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD074000",
+            survey_name="spec",
+            ra=Angle("08:40:50", unit=units.hourangle),
+            dec=Angle("-16:20:42.5", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=60.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD111980",
+            survey_name="spec",
+            ra=Angle("12:53:15", unit=units.hourangle),
+            dec=Angle("-18:31:20.0", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD1151169",
+            survey_name="spec",
+            ra=Angle("13:15:47", unit=units.hourangle),
+            dec=Angle("-29:30:21.2", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD200654",
+            survey_name="spec",
+            ra=Angle("21:06:34", unit=units.hourangle),
+            dec=Angle("-49:57:50.3", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+        Target(
+            target_name="HD205905",
+            survey_name="spec",
+            ra=Angle("21:39:10", unit=units.hourangle),
+            dec=Angle("-27:18:23.7", unit=units.deg),
+            hour_angle_limit=spec_ha_limit,
+            reward_value=reward_values["default"],
+            filters=["r"],
+            visit_gap=4.0,
+            exptime=180.0,
+            nexp=1,
+        ),
+    ]
+
+    image_tiles = [
+        Tiles(
+            survey_name="LATISS_POLE",
+            hour_angle_limit=image_ha_limit_pole,
+            reward_value=reward_values["image_pole"],
+            filters=["r"],
+            visit_gap=image_visit_gap,
+            exptime=image_exptime,
+            nexp=image_nexp,
+        ),
+        Tiles(
+            survey_name="AUXTEL_DRP_IMAGING",
+            hour_angle_limit=image_ha_limit,
+            reward_value=reward_values["image_survey"],
+            filters=["r"],
+            visit_gap=image_visit_gap,
+            exptime=image_exptime,
+            nexp=image_nexp,
+        ),
+    ]
+
+    make_scheduler = MakeScheduler()
+
+    return make_scheduler.get_scheduler(
+        nside=nside,
+        wind_speed_maximum=wind_speed_maximum,
+        survey_type=SurveyType.SpecImage,
+        spec_targets=spec_target_list,
+        image_tiles=image_tiles,
+    )
+
+
+if __name__ == "config":
+    nside, scheduler = get_scheduler()

--- a/Scheduler/v5/auxtel_fbs_image.yaml
+++ b/Scheduler/v5/auxtel_fbs_image.yaml
@@ -17,7 +17,7 @@ auxtel:
     parameters:
       night_boundary: -10.0
     observation_database_name: /home/saluser/rubin_sim_data/fbs_observation_database.sql
-    scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/2022/10/fbs_config_image_survey.py
+    scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/fbs_config_image_survey.py
     default_observing_script_name: auxtel/track_target_and_take_image.py
     default_observing_script_is_standard: true
     stop_tracking_observing_script_name: auxtel/stop_tracking.py

--- a/Scheduler/v5/auxtel_fbs_image_hot.yaml
+++ b/Scheduler/v5/auxtel_fbs_image_hot.yaml
@@ -16,7 +16,7 @@ auxtel:
     parameters:
       night_boundary: -10.0
     observation_database_name: /home/saluser/rubin_sim_data/fbs_observation_database.sql
-    scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/2022/10/fbs_config_image_survey.py
+    scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/fbs_config_image_survey.py
     default_observing_script_name: auxtel/track_target_and_take_image.py
     default_observing_script_is_standard: true
     stop_tracking_observing_script_name: auxtel/stop_tracking.py

--- a/Scheduler/v5/auxtel_fbs_spec_hot_no_dimm.yaml
+++ b/Scheduler/v5/auxtel_fbs_spec_hot_no_dimm.yaml
@@ -16,7 +16,7 @@ auxtel:
     parameters:
       night_boundary: -10.0
     observation_database_name: /home/saluser/rubin_sim_data/fbs_observation_database.sql
-    scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/2022/10/fbs_config_spec_survey.py
+    scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/fbs_config_spec_survey.py
     default_observing_script_name: auxtel/track_target_and_take_image.py
     default_observing_script_is_standard: true
     stop_tracking_observing_script_name: auxtel/stop_tracking.py
@@ -48,10 +48,22 @@ auxtel:
         exposure_time_sequence:
           - 30.0
           - 30.0
+          - 30.0
+          - 30.0
+          - 30.0
+          - 30.0
         filter_sequence:
           - empty_1
           - empty_1
+          - BG40
+          - BG40
+          - OG550
+          - OG550
         grating_sequence:
+          - holo4_003
+          - holo4_003
+          - holo4_003
+          - holo4_003
           - holo4_003
           - holo4_003
   telemetry:

--- a/Scheduler/v5/auxtel_fbs_spec_no_dimm.yaml
+++ b/Scheduler/v5/auxtel_fbs_spec_no_dimm.yaml
@@ -17,7 +17,7 @@ auxtel:
     parameters:
       night_boundary: -10.0
     observation_database_name: /home/saluser/rubin_sim_data/fbs_observation_database.sql
-    scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/2022/10/fbs_config_spec_survey.py
+    scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/fbs_config_spec_survey.py
     default_observing_script_name: auxtel/track_target_and_take_image.py
     default_observing_script_is_standard: true
     stop_tracking_observing_script_name: auxtel/stop_tracking.py
@@ -49,10 +49,22 @@ auxtel:
         exposure_time_sequence:
           - 30.0
           - 30.0
+          - 30.0
+          - 30.0
+          - 30.0
+          - 30.0
         filter_sequence:
           - empty_1
           - empty_1
+          - BG40
+          - BG40
+          - OG550
+          - OG550
         grating_sequence:
+          - holo4_003
+          - holo4_003
+          - holo4_003
+          - holo4_003
           - holo4_003
           - holo4_003
   telemetry:

--- a/Scheduler/v5/auxtel_fbs_spec_photometric_hot_no_dimm.yaml
+++ b/Scheduler/v5/auxtel_fbs_spec_photometric_hot_no_dimm.yaml
@@ -1,8 +1,7 @@
 auxtel:
   driver_type: lsst.ts.scheduler.driver.feature_scheduler
   mode: ADVANCE
-  startup_type: COLD
-  startup_database: /home/saluser/rubin_sim_data/fbs_observation_database.sql
+  startup_type: HOT
   models:
     observatory_model:
       camera:
@@ -17,7 +16,7 @@ auxtel:
     parameters:
       night_boundary: -10.0
     observation_database_name: /home/saluser/rubin_sim_data/fbs_observation_database.sql
-    scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/2022/10/fbs_config_spec_survey.py
+    scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/fbs_config_spec_survey_photometric.py
     default_observing_script_name: auxtel/track_target_and_take_image.py
     default_observing_script_is_standard: true
     stop_tracking_observing_script_name: auxtel/stop_tracking.py
@@ -49,9 +48,42 @@ auxtel:
         exposure_time_sequence:
           - 30.0
           - 30.0
+          - 30.0
+          - 30.0
+          - 30.0
+          - 30.0
         filter_sequence:
           - empty_1
           - empty_1
+          - BG40
+          - BG40
+          - OG550
+          - OG550
         grating_sequence:
           - holo4_003
           - holo4_003
+          - holo4_003
+          - holo4_003
+          - holo4_003
+          - holo4_003
+  telemetry:
+    efd_name: summit_efd
+    streams:
+      - name: seeing
+        efd_table: lsst.sal.DIMM.logevent_dimmMeasurement
+        efd_columns:
+          - fwhm
+        efd_delta_time: 300.0
+        fill_value: 1.0
+      - name: wind_speed
+        efd_table: lsst.sal.WeatherStation.windSpeed
+        efd_columns:
+          - avg2M
+        efd_delta_time: 300.0
+        fill_value: 0.0
+      - name: wind_direction
+        efd_table: lsst.sal.WeatherStation.windDirection
+        efd_columns:
+          - avg2M
+        efd_delta_time: 300.0
+        fill_value: 0.0

--- a/Scheduler/v5/auxtel_fbs_spec_photometric_no_dimm.yaml
+++ b/Scheduler/v5/auxtel_fbs_spec_photometric_no_dimm.yaml
@@ -1,7 +1,8 @@
 auxtel:
   driver_type: lsst.ts.scheduler.driver.feature_scheduler
   mode: ADVANCE
-  startup_type: HOT
+  startup_type: COLD
+  startup_database: /home/saluser/rubin_sim_data/fbs_observation_database.sql
   models:
     observatory_model:
       camera:
@@ -16,7 +17,7 @@ auxtel:
     parameters:
       night_boundary: -10.0
     observation_database_name: /home/saluser/rubin_sim_data/fbs_observation_database.sql
-    scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/2022/10/fbs_config_spec_survey.py
+    scheduler_config: ts_config_ocs/Scheduler/feature_scheduler/auxtel/fbs_config_spec_survey_photometric.py
     default_observing_script_name: auxtel/track_target_and_take_image.py
     default_observing_script_is_standard: true
     stop_tracking_observing_script_name: auxtel/stop_tracking.py
@@ -48,9 +49,42 @@ auxtel:
         exposure_time_sequence:
           - 30.0
           - 30.0
+          - 30.0
+          - 30.0
+          - 30.0
+          - 30.0
         filter_sequence:
           - empty_1
           - empty_1
+          - BG40
+          - BG40
+          - OG550
+          - OG550
         grating_sequence:
           - holo4_003
           - holo4_003
+          - holo4_003
+          - holo4_003
+          - holo4_003
+          - holo4_003
+  telemetry:
+    efd_name: summit_efd
+    streams:
+      - name: seeing
+        efd_table: lsst.sal.DIMM.logevent_dimmMeasurement
+        efd_columns:
+          - fwhm
+        efd_delta_time: 300.0
+        fill_value: 1.0
+      - name: wind_speed
+        efd_table: lsst.sal.WeatherStation.windSpeed
+        efd_columns:
+          - avg2M
+        efd_delta_time: 300.0
+        fill_value: 0.0
+      - name: wind_direction
+        efd_table: lsst.sal.WeatherStation.windDirection
+        efd_columns:
+          - avg2M
+        efd_delta_time: 300.0
+        fill_value: 0.0


### PR DESCRIPTION
Hi Tiago, new scheduler configurations for the 2023-01A run. I'm also attaching outputs of the simulations I ran for all three files: imaging, spec, and spec_photometric. These were run locally with rubin_sim v0.14.0 
<img width="616" alt="Screen Shot 2023-01-12 at 4 40 23 PM" src="https://user-images.githubusercontent.com/17299652/212355270-b7665583-be85-4dc7-b5f6-8ea44404e618.png">
<img width="615" alt="Screen Shot 2023-01-12 at 4 41 23 PM" src="https://user-images.githubusercontent.com/17299652/212355276-7ac8bb51-4038-4901-88df-17b92f34021b.png">
<img width="612" alt="Screen Shot 2023-01-12 at 4 43 19 PM" src="https://user-images.githubusercontent.com/17299652/212355279-0de81c5d-72d2-4f2a-b2d4-5a56995d6f79.png">
