### PR TITLE
tickets/BLOCK-296

### DIFF
--- a/Scheduler/observing_blocks_auxtel/BLOCK-274/BLOCK-274_HD212320.json
+++ b/Scheduler/observing_blocks_auxtel/BLOCK-274/BLOCK-274_HD212320.json
@@ -1,0 +1,516 @@
+{
+    "name": "BLOCK-274",
+    "id": "1c8ed455-b391-4fef-9a5b-b2def3fe0a29",
+    "program": "BLOCK-274_HD212320",
+    "constraints": [],
+    "scripts": [
+        {
+            "name": "auxtel/latiss_acquire.py",
+            "standard": false,
+            "parameters": {
+                "object_name": "HD212320",
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "acq_grating": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": -8.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/offset_atcs.py",
+            "standard": true,
+            "parameters": {
+                "offset_xy": {
+                    "x": 1.0,
+                    "y": 0
+                }
+            }
+        },
+        {
+            "name": "auxtel/latiss_take_sequence.py",
+            "standard": true,
+            "parameters": {
+                "program": "BLOCK-274",
+                "reason": "SITCOM-1353",
+                "exposure_time_sequence": [
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30,
+                    30
+                ],
+                "filter_sequence": "empty_1",
+                "grating_sequence": "holo4_003"
+            }
+        },
+        {
+            "name": "auxtel/stop_tracking.py",
+            "standard": true,
+            "parameters": {}
+        }
+    ]
+}

--- a/Scheduler/observing_blocks_auxtel/BLOCK-296/BLOCK-296_g.json
+++ b/Scheduler/observing_blocks_auxtel/BLOCK-296/BLOCK-296_g.json
@@ -1,0 +1,274 @@
+{
+  "name": "BLOCK-296_g",
+  "id": "f1a84402-a980-438e-b32c-7ce9f80e9c02",
+  "program": "BLOCK-296_g",
+  "constraints": [],
+  "scripts": [
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 80,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-g",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSg_65mm",
+          "SDSSg_65mm",
+          "SDSSg_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 50,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-g",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSg_65mm",
+          "SDSSg_65mm",
+          "SDSSg_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 40,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-g",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSg_65mm",
+          "SDSSg_65mm",
+          "SDSSg_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 30,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-g",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30,
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSg_65mm",
+          "SDSSg_65mm",
+          "SDSSg_65mm",
+          "SDSSg_65mm",
+          "SDSSg_65mm",
+          "SDSSg_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1",
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 40,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-g",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSg_65mm",
+          "SDSSg_65mm",
+          "SDSSg_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 50,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-g",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSg_65mm",
+          "SDSSg_65mm",
+          "SDSSg_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 80,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-g",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSg_65mm",
+          "SDSSg_65mm",
+          "SDSSg_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/stop_tracking.py",
+      "standard": true,
+      "parameters": {}
+    }
+  ]
+}

--- a/Scheduler/observing_blocks_auxtel/BLOCK-296/BLOCK-296_r.json
+++ b/Scheduler/observing_blocks_auxtel/BLOCK-296/BLOCK-296_r.json
@@ -1,0 +1,274 @@
+{
+  "name": "BLOCK-296_r",
+  "id": "1e4ad24b-1a62-4fb4-93fe-723853aa7574",
+  "program": "BLOCK-296_r",
+  "constraints": [],
+  "scripts": [
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 80,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-r",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSr_65mm",
+          "SDSSr_65mm",
+          "SDSSr_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 50,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-r",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSr_65mm",
+          "SDSSr_65mm",
+          "SDSSr_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 40,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-r",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSr_65mm",
+          "SDSSr_65mm",
+          "SDSSr_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 30,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-r",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30,
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSr_65mm",
+          "SDSSr_65mm",
+          "SDSSr_65mm",
+          "SDSSr_65mm",
+          "SDSSr_65mm",
+          "SDSSr_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1",
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 40,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-r",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSr_65mm",
+          "SDSSr_65mm",
+          "SDSSr_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 50,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-r",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSr_65mm",
+          "SDSSr_65mm",
+          "SDSSr_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 80,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-r",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSr_65mm",
+          "SDSSr_65mm",
+          "SDSSr_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/stop_tracking.py",
+      "standard": true,
+      "parameters": {}
+    }
+  ]
+}

--- a/Scheduler/observing_blocks_auxtel/BLOCK-296/BLOCK-296_y.json
+++ b/Scheduler/observing_blocks_auxtel/BLOCK-296/BLOCK-296_y.json
@@ -1,0 +1,274 @@
+{
+  "name": "BLOCK-296_y",
+  "id": "8d41e362-8bbb-47a3-91ea-3b4189524819",
+  "program": "BLOCK-296_y",
+  "constraints": [],
+  "scripts": [
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 80,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-y",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ],
+        "grating_sequence": [
+          "SDSSy_65mm",
+          "SDSSy_65mm",
+          "SDSSy_65mm"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 50,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-y",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ],
+        "grating_sequence": [
+          "SDSSy_65mm",
+          "SDSSy_65mm",
+          "SDSSy_65mm"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 40,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-y",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ],
+        "grating_sequence": [
+          "SDSSy_65mm",
+          "SDSSy_65mm",
+          "SDSSy_65mm"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 30,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-y",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30,
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1",
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ],
+        "grating_sequence": [
+          "SDSSy_65mm",
+          "SDSSy_65mm",
+          "SDSSy_65mm",
+          "SDSSy_65mm",
+          "SDSSy_65mm",
+          "SDSSy_65mm"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 40,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-y",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ],
+        "grating_sequence": [
+          "SDSSy_65mm",
+          "SDSSy_65mm",
+          "SDSSy_65mm"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 50,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-y",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ],
+        "grating_sequence": [
+          "SDSSy_65mm",
+          "SDSSy_65mm",
+          "SDSSy_65mm"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 80,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-y",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ],
+        "grating_sequence": [
+          "SDSSy_65mm",
+          "SDSSy_65mm",
+          "SDSSy_65mm"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/stop_tracking.py",
+      "standard": true,
+      "parameters": {}
+    }
+  ]
+}

--- a/Scheduler/observing_blocks_auxtel/BLOCK-296/BLOCK-296_z.json
+++ b/Scheduler/observing_blocks_auxtel/BLOCK-296/BLOCK-296_z.json
@@ -1,0 +1,274 @@
+{
+  "name": "BLOCK-296_z",
+  "id": "4399f02e-2850-4194-9b67-3ae9f00c6c4f",
+  "program": "BLOCK-296_z",
+  "constraints": [],
+  "scripts": [
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 80,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-z",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSz_65mm",
+          "SDSSz_65mm",
+          "SDSSz_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 50,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-z",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSz_65mm",
+          "SDSSz_65mm",
+          "SDSSz_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 40,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-z",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSz_65mm",
+          "SDSSz_65mm",
+          "SDSSz_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 30,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-z",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30,
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSz_65mm",
+          "SDSSz_65mm",
+          "SDSSz_65mm",
+          "SDSSz_65mm",
+          "SDSSz_65mm",
+          "SDSSz_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1",
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 40,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-z",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSz_65mm",
+          "SDSSz_65mm",
+          "SDSSz_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 50,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-z",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSz_65mm",
+          "SDSSz_65mm",
+          "SDSSz_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/track_target.py",
+      "standard": true,
+      "parameters": {
+        "find_target": {
+          "el": 80,
+          "az": 0,
+          "mag_limit": 10.0,
+          "radius": 5,
+          "mag_range": 4.0
+        }
+      }
+    },
+    {
+      "name": "auxtel/latiss_take_sequence.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-296",
+        "reason": "SITCOM-1375-z",
+        "exposure_time_sequence": [
+          30,
+          30,
+          30
+        ],
+        "filter_sequence": [
+          "SDSSz_65mm",
+          "SDSSz_65mm",
+          "SDSSz_65mm"
+        ],
+        "grating_sequence": [
+          "empty_1",
+          "empty_1",
+          "empty_1"
+        ]
+      }
+    },
+    {
+      "name": "auxtel/stop_tracking.py",
+      "standard": true,
+      "parameters": {}
+    }
+  ]
+}

--- a/Scheduler/observing_blocks_auxtel/BLOCK-299.json
+++ b/Scheduler/observing_blocks_auxtel/BLOCK-299.json
@@ -1,0 +1,62 @@
+{
+  "name": "BLOCK-299",
+  "id": "6e465102-ce17-42a0-8c79-0d13c9788984",
+  "program": "BLOCK-299",
+  "constraints": [],
+  "scripts": [
+    {
+      "name": "auxtel/stop_tracking.py",
+      "standard": true,
+      "parameters": {}
+    },
+    {
+      "name": "run_command.py",
+      "standard": true,
+      "parameters": {
+        "component": "ATDomeTrajectory",
+        "cmd": "setFollowingMode",
+        "parameters": {
+          "enable": false
+        }
+      }
+    },
+    {
+      "name": "auxtel/atdome/home_dome.py",
+      "standard": true,
+      "parameters": {}
+    },
+    {
+      "name": "auxtel/point_azel.py",
+      "standard": true,
+      "parameters": {
+        "el": 25.8,
+        "az": 53.2,
+        "rot_tel": 0.0
+      }
+    },
+    {
+      "name": "auxtel/take_image_latiss.py",
+      "standard": true,
+      "parameters": {
+        "program": "BLOCK-299",
+        "reason": "SITCOM-1314",
+        "exp_times": 2,
+        "nimages": 100,
+        "filter": "SDSSg_65mm",
+        "grating": "empty_1",
+        "image_type": "ENGTEST"
+      }
+    },
+    {
+      "name": "run_command.py",
+      "standard": true,
+      "parameters": {
+        "component": "ATDomeTrajectory",
+        "cmd": "setFollowingMode",
+        "parameters": {
+          "enable": true
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This block performs a sweep in elevation (going down and then back up) to back out atmospheric seeing vs other forms of seeing. I wrote a different block for each filter available in the AuxTel filter wheels.