### PR TITLE
MTScheduler: Add a BLOCK-T4 for CameraHex warm-up.

### DIFF
--- a/Scheduler/observing_blocks_maintel/BLOCK-T4.json
+++ b/Scheduler/observing_blocks_maintel/BLOCK-T4.json
@@ -1,0 +1,56 @@
+{
+    "name": "BLOCK-T4",
+    "program": "BLOCK-T4",
+    "constraints": [],
+    "scripts": [
+        {
+            "name": "maintel/disable_hexapod_compensation_mode.py",
+            "standard": true,
+            "parameters": {
+                "components": [
+                    "CameraHexapod"
+                ]
+            }
+        },
+        {
+            "name": "run_command.py",
+            "standard": true,
+            "parameters": {
+                "component": "MTHexapod:1",
+                "cmd": "move",
+                "parameters": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 0,
+                    "u": 0,
+                    "v": 0,
+                    "w": 0
+                }
+            }
+        },
+        {
+            "name": "maintel/warmup_hexapod.py",
+            "standard": false,
+            "parameters": {
+                "hexapod": "camera",
+                "max_position": 5000
+            }
+        },
+        {
+            "name": "run_command.py",
+            "standard": true,
+            "parameters": {
+                "component": "MTHexapod:1",
+                "cmd": "move",
+                "parameters": {
+                    "x": 0,
+                    "y": 0,
+                    "z": 0,
+                    "u": 0,
+                    "v": 0,
+                    "w": 0
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Hi Bruno. Please, check that everything is fine. 

Note: I'm now using the ``disable_hexapod_compensation_mode.py`` script instead of the run command to disable the compensation mode before moving things.