### PR TITLE
DM-48944 Add configuration for DREAM use of LFA.

### DIFF
--- a/DREAM/v4/_base.yaml
+++ b/DREAM/v4/_base.yaml
@@ -1,0 +1,1 @@
+s3instance: ls

--- a/DREAM/v4/_init.yaml
+++ b/DREAM/v4/_init.yaml
@@ -1,0 +1,9 @@
+host: "127.0.0.1"
+port: 5000
+connection_timeout: 10
+read_timeout: 10
+poll_interval: 10
+ess_index: 301
+battery_low_threshold: 25
+s3instance: test
+data_product_path: "/tmp"

--- a/DREAM/v4/_summit.yaml
+++ b/DREAM/v4/_summit.yaml
@@ -1,0 +1,3 @@
+host: "dream-b.cp.lsst.org"
+s3instance: cp
+data_product_path: "/srv"

--- a/DREAM/v4/_tucson.yaml
+++ b/DREAM/v4/_tucson.yaml
@@ -1,0 +1,1 @@
+s3instance: tuc


### PR DESCRIPTION
New configuration items so that the DREAM CSC can pull images from an HTTP server on the DREAM machine and upload them to LFA. 

See https://github.com/lsst-ts/ts_dream/pull/12