### PR TITLE
DM-49550: changed image server for fiber spec config

### DIFF
--- a/FiberSpectrograph/v4/_summit.yaml
+++ b/FiberSpectrograph/v4/_summit.yaml
@@ -1,3 +1,3 @@
 s3instance: cp
-image_service_url: "http://comcam-mcm-dds.cp.lsst.org"
-location: auxtel
+image_service_url: "https://ccs.lsst.org"
+location: dome


### PR DESCRIPTION
Change image server from 
`http://comcam-mcm-dds.cp.lsst.org/` to `https://ccs.lsst.org/`