### PR TITLE
tickets/DM-49682

### DIFF
--- a/FiberSpectrograph/v4/_summit.yaml
+++ b/FiberSpectrograph/v4/_summit.yaml
@@ -1,3 +1,3 @@
 s3instance: cp
-image_service_url: "https://ccs.lsst.org"
+image_service_url: "http://ccs.lsst.org"
 location: dome


### PR DESCRIPTION
Revert FiberSpectrograph image naming service connection back to http.