### PR TITLE
DM-49914: Update scheduler configuration for LSSTCam small-field science program observations

### DIFF
--- a/Scheduler/feature_scheduler/maintel/fieldsurvey_centers.yaml
+++ b/Scheduler/feature_scheduler/maintel/fieldsurvey_centers.yaml
@@ -165,4 +165,40 @@ Seagull:
 rotator_test_target:
   # test target for closed-dome rotator tracking test 
   ra: 0.0
-  dec: -17.0 
+  dec: -17.0
+WDFS0956-38:
+  # CalSpec
+  ra: 149.2375833
+  dec: -38.69153611
+WDFS1055-36:
+  # CalSpec
+  ra: 163.8557667
+  dec: -36.20429722
+WDFS1110-17:
+  # CalSpec
+  ra: 167.7476208
+  dec: -17.16505
+WDFS1206-27:
+  # CalSpec
+  ra: 181.5847958
+  dec: -27.49463333
+WDFS1434-28:
+  # CalSpec
+  ra: 218.7482792
+  dec: -28.31766389
+WDFS1535-77:
+  # CalSpec
+  ra: 233.9387917
+  dec: -77.41225833
+SF1615+001A:
+  # CalSpec
+  ra: 244.5593333
+  dec: 0.002391667
+WDFS1837-70:
+  # CalSpec
+  ra: 279.324475
+  dec: -70.04758333
+NGC_6681:
+  # Multiple CalSpec stars in globular cluster
+  ra: 280.80
+  dec: -32.29


### PR DESCRIPTION
This PR is intended to 
- Add targets for spectrophotometric standard star observations
- Fine-tune dither pattern for various targets
- Adjust exposure times ( u: 38s;  grizy: 29.2s) – see Section 3.2 of https://pstn-056.lsst.io/PSTN-056.pdf