### PR TITLE
Scheduler: In test_scheduler_observing_blocks.py unit test, add obser…

### DIFF
--- a/tests/test_scheduler_observing_blocks.py
+++ b/tests/test_scheduler_observing_blocks.py
@@ -160,4 +160,5 @@ def get_driver_overrides() -> dict:
         ],
         "estimated_slew_time": 0.0,
         "program": "PROGRAM",
+        "observation_reason": "REASON",
     }


### PR DESCRIPTION
…vation_reason to the list of driver overrides.