### PR TITLE
DM-50750 EAS v4

### DIFF
--- a/EAS/v4/_init.yaml
+++ b/EAS/v4/_init.yaml
@@ -1,0 +1,9 @@
+wind_threshold: 5
+wind_average_window: 1800
+wind_minimum_window: 600
+vec04_hold_time: 300
+features_to_disable: []
+twilight_definition: astronomical
+weather_ess_index: 301
+glycol_setpoint_delta: -2
+heater_setpoint_delta: -1


### PR DESCRIPTION
Adds:
 * `features_to_disable` to specify that some functions should not be used
 * `twilight_definition` to specify when end-of-twilight conditions should be observed.
 * `weather_ess_index` to specify the SAL index for the weather station
 * `glycol_setpoint_delta` and `heater_setpoint_delta` to specify the setpoints that should be sent to M1M3TS.