### PR TITLE
EAS v5

### DIFF
--- a/EAS/v4/disable_m1m3ts.yaml
+++ b/EAS/v4/disable_m1m3ts.yaml
@@ -1,0 +1,2 @@
+features_to_disable:
+  - m1m3ts

--- a/EAS/v5/_init.yaml
+++ b/EAS/v5/_init.yaml
@@ -1,0 +1,10 @@
+wind_threshold: 5
+wind_average_window: 1800
+wind_minimum_window: 600
+vec04_hold_time: 300
+m1m3_setpoint_cadence: 300
+features_to_disable: []
+twilight_definition: astronomical
+weather_ess_index: 301
+glycol_setpoint_delta: -2
+heater_setpoint_delta: -1

--- a/EAS/v5/disable_m1m3ts.yaml
+++ b/EAS/v5/disable_m1m3ts.yaml
@@ -1,0 +1,2 @@
+features_to_disable:
+  - m1m3ts


### PR DESCRIPTION
This commit adds v5 for EAS (subject to further revision before the CSC adopts it) and adds a `disable_m1m3ts` configuration that ignores M1M3TS and continues to control the HVAC.