### PR TITLE
DREAM v6

### DIFF
--- a/DREAM/v6/_base.yaml
+++ b/DREAM/v6/_base.yaml
@@ -1,0 +1,1 @@
+s3instance: ls

--- a/DREAM/v6/_init.yaml
+++ b/DREAM/v6/_init.yaml
@@ -1,0 +1,18 @@
+host: "127.0.0.1"
+port: 5000
+connection_timeout: 10
+read_timeout: 10
+poll_interval: 10
+ess_index: 301
+battery_low_threshold: 25
+s3instance: test
+data_product_host:
+  N: 127.0.0.1:5001
+  S: 127.0.0.1:5001
+  E: 127.0.0.1:5001
+  W: 127.0.0.1:5001
+  C: 127.0.0.1:5001
+  B: 127.0.0.1:5001
+data_product_path: "/tmp"
+run_data_product_loop: true
+skip_tmpdata_products: true

--- a/DREAM/v6/_summit.yaml
+++ b/DREAM/v6/_summit.yaml
@@ -1,0 +1,9 @@
+host: "dream-b.cp.lsst.org"
+s3instance: cp
+data_product_host:
+  N: dream-n.cp.lsst.org
+  S: dream-x.cp.lsst.org
+  E: dream-e.cp.lsst.org
+  W: dream-w.cp.lsst.org
+  C: dream-c.cp.lsst.org
+  B: dream-b.cp.lsst.org

--- a/DREAM/v6/_tucson.yaml
+++ b/DREAM/v6/_tucson.yaml
@@ -1,0 +1,1 @@
+s3instance: tuc

--- a/DREAM/v6/no_data_products.yaml
+++ b/DREAM/v6/no_data_products.yaml
@@ -1,0 +1,1 @@
+run_data_product_loop: false

--- a/DREAM/v6/upload_tmpdata.yaml
+++ b/DREAM/v6/upload_tmpdata.yaml
@@ -1,0 +1,1 @@
+skip_tmpdata_products: false


### PR DESCRIPTION
- Allows DREAM to pull from multiple http servers for data products
- Creates configuration item to skip temporary data products, makes that the default