### PR TITLE
OSW-752: Add EAS configuration items.

### DIFF
--- a/EAS/v6/_init.yaml
+++ b/EAS/v6/_init.yaml
@@ -14,4 +14,6 @@ top_end_setpoint_delta: -1
 setpoint_deadband_heating: 0.10
 setpoint_deadband_cooling: 0.10
 maximum_heating_rate: 1.0
+slow_cooling_rate: 1.00
+fast_cooling_rate: 10.0
 setpoint_lower_limit: 6


### PR DESCRIPTION
Adds two new items to EAS for the cooling rate limit.