### PR TITLE
MTScheduler: Add BLOCK-T600

### DIFF
--- a/Scheduler/observing_blocks_maintel/AOS/BLOCK-T600.json
+++ b/Scheduler/observing_blocks_maintel/AOS/BLOCK-T600.json
@@ -1,0 +1,19 @@
+{
+    "name": "BLOCK-T600",
+    "program": "BLOCK-T600",
+    "constraints": [],
+    "scripts": [
+        {
+            "name": "maintel/take_aos_sequence_lsstcam.py",
+            "standard": true,
+            "parameters": {
+                "exposure_time": 60.0,
+                "dz": 7500,
+                "n_sequences": 1,
+                "program": "$program",
+                "reason": "SITCOM-2194",
+                "note": "dalmatian_pattern_investigation"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Add BLOCK-T600 for pistoning the LSST Camera to take a giant donut exposure for the purpose of further investigating the Dalmatian pattern.