### PR TITLE
tickets/RSO-248

### DIFF
--- a/Watcher/v6/_summit.yaml
+++ b/Watcher/v6/_summit.yaml
@@ -222,6 +222,48 @@ rules:
     hysteresis: 0.2
     poll_interval: 1
     max_data_age: 30
+  - name: Simonyi
+    dew_point_sensors:
+    - sal_index: 111  # see ESS configuration
+      sensor_names:
+      - "Camera-ESS01"
+    - sal_index: 112  # see ESS configuration
+      sensor_names:
+      - "M2-ESS02"
+    - sal_index: 113  # see ESS configuration
+      sensor_names:
+      - "M1M3-ESS03"
+    temperature_sensors:
+    - sal_index: 111  # see ESS configuration
+      sensor_info:
+      - sensor_name: "Camera-ESS01"
+    - sal_index: 112  # see ESS configuration
+      sensor_info:
+      - sensor_name: "M2-ESS02"
+    - sal_index: 113  # see ESS configuration
+      sensor_info:
+      - sensor_name: "M1M3-ESS03"
+    warning_level: 3
+    serious_level: 2.5
+    critical_level: 2
+    hysteresis: 0.2
+    poll_interval: 1
+    max_data_age: 30
+  - name: Simonyi External
+    dew_point_sensors:
+    - sal_index: 301 # see ESS configuration
+      sensor_names:
+      - "Weather tower computed dew point"
+    temperature_sensors:
+    - sal_index: 301 # see ESS configuration
+      sensor_info:
+      - sensor_name: "Weather tower air temperature"
+    warning_level: 3
+    serious_level: 2.5
+    critical_level: 2
+    hysteresis: 0.2
+    poll_interval: 1
+    max_data_age: 30
 - classname: Humidity
   configs:
   - name: AT


### PR DESCRIPTION
Hi Erik,

I added the new DewPointDepression watcher configurations to the summit.yaml file. Given that we do not have LSSTCam telemetry for watcher alarms, the following has been included instead:

1. Simonyi + Simonyi External DewPointDepression: Inside and outside alarms the observatory. 
2. M2 and M1M3 DewPointDepression alarms.

NOTE: I am keeping AT External, despite the fact that it uses the same ESS 301 telemetry as Simonyi External, because the limits are slightly different between AuxTel and Simonyi. But if we want AuxTel to close when Simonyi closes, I might condense them into a WeatherStation alarm, instead.

The alarms are updated to have warning = 3°C, serious = 2.5°C, and critical = 2°C. Please take a look, and let me know if you have any comments.